### PR TITLE
Update view to match with the latest CUR report schema

### DIFF
--- a/cost_and_usage.view.lkml
+++ b/cost_and_usage.view.lkml
@@ -5,21 +5,21 @@ view: cost_and_usage {
   dimension: bill_billing_entity {
     type: string
     hidden: yes
-    sql: ${TABLE}.bill_billingentity ;;
+    sql: ${TABLE}.bill_billing_entity ;;
   }
 
   dimension_group: billing_period_end {
     view_label: "Billing Info"
     type: time
     timeframes: [time,date,week,month,year]
-    sql: from_iso8601_timestamp(${TABLE}.bill_billingperiodenddate);;
+    sql: from_iso8601_timestamp(date_format(${TABLE}.bill_billing_period_end_date,'%Y-%m-%dT%H:%i:%s')) ;;
   }
 
   dimension_group: billing_period_start {
     view_label: "Billing Info"
     type: time
     timeframes: [time,date,week,month,year]
-    sql: from_iso8601_timestamp(${TABLE}.bill_billingperiodstartdate) ;;
+    sql: from_iso8601_timestamp(date_format(${TABLE}.bill_billing_period_start_date,'%Y-%m-%dT%H:%i:%s')) ;;
   }
 
 
@@ -27,64 +27,64 @@ view: cost_and_usage {
     label: "Type"
     view_label: "Billing Info"
     type: string
-    sql: ${TABLE}.bill_billtype ;;
+    sql: ${TABLE}.bill_bill_type ;;
   }
 
   dimension: bill_invoiceid {
     type: string
     hidden: yes
-    sql: ${TABLE}.bill_invoiceid ;;
+    sql: ${TABLE}.bill_invoice_id ;;
   }
 
   dimension: bill_payeraccountid {
     type: string
     hidden: yes
-    sql: ${TABLE}.bill_payeraccountid ;;
+    sql: ${TABLE}.bill_payer_account_id ;;
   }
 
   dimension: identity_lineitemid {
     type: string
     hidden: yes
-    sql: ${TABLE}.identity_lineitemid ;;
+    sql: ${TABLE}.identity_line_item_id ;;
   }
 
   dimension: identity_timeinterval {
     type: string
     hidden: yes
-    sql: ${TABLE}.identity_timeinterval ;;
+    sql: ${TABLE}.identity_time_interval ;;
   }
 
   dimension: lineitem_availabilityzone {
     type: string
     hidden: yes
-    sql: ${TABLE}.lineitem_availabilityzone ;;
+    sql: ${TABLE}.line_item_availability_zone ;;
   }
 
   dimension: lineitem_blendedcost {
     hidden: yes
     type: number
-    sql: ${TABLE}.lineitem_blendedcost ;;
+    sql: ${TABLE}.line_item_blended_cost ;;
   }
 
   dimension: blended_rate {
     view_label: "Line Items (Individual Charges)"
     description: "The rate applied to this line item for a consolidated billing account in an organization."
     type: number
-    sql: ${TABLE}.lineitem_blendedrate ;;
+    sql: ${TABLE}.line_item_blended_rate ;;
   }
 
   dimension: lineitem_currencycode {
     label: "Currency Code"
     view_label: "Line Items (Individual Charges)"
     type: string
-    sql: ${TABLE}.lineitem_currencycode ;;
+    sql: ${TABLE}.line_item_currency_code ;;
   }
 
   dimension: description {
     view_label: "Line Items (Individual Charges)"
     description: "A description of the pricing tier covered by this line item"
     type: string
-    sql: ${TABLE}.lineitem_lineitemdescription ;;
+    sql: ${TABLE}.line_item_line_item_description ;;
   }
 
 
@@ -94,28 +94,28 @@ view: cost_and_usage {
     view_label: "Line Items (Individual Charges)"
     description: "Fee is one-time RI expense for all-upfront or partial-upfront. RI Fee is recurring RI expense for partial-upfront and no-upfront RI expenses."
     type: string
-    sql: ${TABLE}.lineitem_lineitemtype ;;
+    sql: ${TABLE}.line_item_line_item_type ;;
   }
 
   dimension: type_ri_fee_upfront {
     view_label: "Reserved Units"
     description: "Fee is one-time RI expense for all-upfront or partial-upfront."
     type: string
-    sql: CASE WHEN ${TABLE}.lineitem_lineitemtype = 'Fee' THEN 'Fee' ELSE 'Other' END ;;
+    sql: CASE WHEN ${TABLE}.line_item_line_item_type = 'Fee' THEN 'Fee' ELSE 'Other' END ;;
   }
 
   dimension: type_ri_fee_on_demand {
     view_label: "Reserved Units"
     description: "RI Fee is recurring RI expense for partial-upfront and no-upfront RI expenses."
     type: string
-    sql: CASE WHEN ${TABLE}.lineitem_lineitemtype = 'RIFee' THEN 'RI Fee' ELSE 'Other' END ;;
+    sql: CASE WHEN ${TABLE}.line_item_line_item_type = 'RIFee' THEN 'RI Fee' ELSE 'Other' END ;;
   }
 
   dimension: type_discounted_usage {
     view_label: "Reserved Units"
     description: "Describes the instance usage that recieved a matching RI discount benefit. It is added to the bill once a reserved instance experiences usage. Cost will always be zero because it's been accounted for with Fee and RI Fee."
     type: string
-    sql: CASE WHEN ${TABLE}.lineitem_lineitemtype = 'DiscountedUsage' THEN 'Discounted Usage' ELSE 'Other' END ;;
+    sql: CASE WHEN ${TABLE}.line_item_line_item_type = 'DiscountedUsage' THEN 'Discounted Usage' ELSE 'Other' END ;;
   }
 
   dimension: ri_line_item {
@@ -139,33 +139,33 @@ view: cost_and_usage {
     view_label: "Line Items (Individual Charges)"
     description: "Degree of instance size flexibility provided by RIs"
     type: number
-    sql: ${TABLE}.lineitem_normalizationfactor ;;
+    sql: ${TABLE}.line_item_normalization_factor ;;
   }
 
   dimension: lineitem_normalizedusageamount {
     hidden: yes
     type: number
-    sql: ${TABLE}.lineitem_normalizedusageamount ;;
+    sql: ${TABLE}.line_item_normalized_usage_amount ;;
   }
 
   dimension: line_item_operation {
     label: "Operation"
     view_label: "Line Items (Individual Charges)"
     type: string
-    sql: ${TABLE}.lineitem_operation ;;
+    sql: ${TABLE}.line_item_operation ;;
   }
 
   dimension: product_code {
     description: "The AWS product/service being used"
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.lineitem_productcode ;;
+    sql: ${TABLE}.line_item_product_code ;;
   }
 
   dimension: lineitem_resourceid {
     type: string
     hidden: no
-    sql: ${TABLE}.lineitem_resourceid ;;
+    sql: ${TABLE}.line_item_resource_id ;;
     tags: ["aws_resource_id"]
   }
 
@@ -173,20 +173,20 @@ view: cost_and_usage {
     label: "Tax Type"
     view_label: "Line Items (Individual Charges)"
     type: string
-    sql: ${TABLE}.lineitem_taxtype ;;
+    sql: ${TABLE}.line_item_tax_type ;;
   }
 
   dimension: lineitem_unblendedcost {
     type: number
     hidden: yes
-    sql: ${TABLE}.lineitem_unblendedcost ;;
+    sql: ${TABLE}.line_item_unblended_cost ;;
   }
 
   dimension: unblended_rate {
     view_label: "Line Items (Individual Charges)"
     description: "The rate that this line item would have been charged for an unconsolidated account."
     type: number
-    sql: ${TABLE}.lineitem_unblendedrate ;;
+    sql: ${TABLE}.line_item_unblended_rate ;;
   }
 
   dimension: lineitem_usageaccountid {
@@ -195,27 +195,28 @@ view: cost_and_usage {
     description: "RIs can span multiple accounts - this dimensions related to usage"
     type: string
     # hidden: yes
-    sql: ${TABLE}.lineitem_usageaccountid ;;
+    sql: ${TABLE}.line_item_usage_account_id ;;
   }
 
   dimension: lineitem_usageamount {
     type: number
     hidden: yes
-    sql: ${TABLE}.lineitem_usageamount ;;
+    sql: ${TABLE}.line_item_usage_amount ;;
   }
 
   dimension_group: usage_end {
     view_label: "Line Items (Individual Charges)"
     type: time
     timeframes: [raw, time,time_of_day,hour,date,week,day_of_week,month,month_name,year]
-    sql: from_iso8601_timestamp(${TABLE}.lineitem_usageenddate) ;;
+    sql: from_iso8601_timestamp(date_format(${TABLE}.line_item_usage_end_date,'%Y-%m-%dT%H:%i:%s')) ;;
   }
 
   dimension_group: usage_start {
     view_label: "Line Items (Individual Charges)"
     type: time
     timeframes: [raw, time,time_of_day,hour,date,week,day_of_week,month,month_name,year]
-    sql: from_iso8601_timestamp(${TABLE}.lineitem_usagestartdate);;
+    #sql: from_iso8601_timestamp(${TABLE}.line_item_usage_start_date);;
+    sql: from_iso8601_timestamp(date_format(${TABLE}.line_item_usage_start_date,'%Y-%m-%dT%H:%i:%s'));;
   }
 
   dimension: usage_hours {
@@ -235,28 +236,7 @@ view: cost_and_usage {
     view_label: "Line Items (Individual Charges)"
     description: "The type of usage covered by this line item. If you paid for a Reserved Instance, the report has one line that shows the monthly committed cost, and multiple lines that show a charge of 0."
     type: string
-    sql: ${TABLE}.lineitem_usagetype ;;
-  }
-
-  dimension: product_accountassistance {
-    label: "Account Assistance"
-    view_label: "Product Info"
-    type: string
-    sql: ${TABLE}.product_accountassistance ;;
-  }
-
-  dimension: product_architecturalreview {
-    label: "Architecture Review"
-    view_label: "Product Info"
-    type: string
-    sql: ${TABLE}.product_architecturalreview ;;
-  }
-
-  dimension: product_architecturesupport {
-    label: "Architecture Support"
-    view_label: "Product Info"
-    type: string
-    sql: ${TABLE}.product_architecturesupport ;;
+    sql: ${TABLE}.line_item_usage_type ;;
   }
 
   dimension: product_availability {
@@ -266,68 +246,44 @@ view: cost_and_usage {
     sql: ${TABLE}.product_availability ;;
   }
 
-  dimension: product_bestpractices {
-    hidden: yes
-    type: string
-    sql: ${TABLE}.product_bestpractices ;;
-  }
-
   dimension: product_cacheengine {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_cacheengine ;;
+    sql: ${TABLE}.product_cache_engine ;;
   }
 
-  dimension: product_caseseverityresponsetimes {
-    hidden: yes
-    type: string
-    sql: ${TABLE}.product_caseseverityresponsetimes ;;
-  }
 
   dimension: product_clockspeed {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_clockspeed ;;
+    sql: ${TABLE}.product_clock_speed ;;
   }
 
   dimension: product_currentgeneration {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_currentgeneration ;;
-  }
-
-  dimension: product_customerserviceandcommunities {
-    hidden: yes
-    type: string
-    sql: ${TABLE}.product_customerserviceandcommunities ;;
-  }
-
-  dimension: product_databaseedition {
-    label: "Database Edition"
-    view_label: "Product Info"
-    type: string
-    sql: ${TABLE}.product_databaseedition ;;
+    sql: ${TABLE}.product_current_generation ;;
   }
 
   dimension: product_databaseengine {
     label: "Database Engine"
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.product_databaseengine ;;
+    sql: ${TABLE}.product_database_engine ;;
   }
 
   dimension: product_dedicatedebsthroughput {
     label: "Dedicated EBS Throughput"
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.product_dedicatedebsthroughput ;;
+    sql: ${TABLE}.product_dedicated_ebs_throughput ;;
   }
 
   dimension: product_deploymentoption {
     view_label: "Product Info"
     hidden: yes
     type: string
-    sql: ${TABLE}.product_deploymentoption ;;
+    sql: ${TABLE}.product_deployment_option ;;
   }
 
   dimension: product_description {
@@ -344,12 +300,6 @@ view: cost_and_usage {
     sql: ${TABLE}.product_durability ;;
   }
 
-  dimension: product_ebsoptimized {
-    hidden: yes
-    type: string
-    sql: ${TABLE}.product_ebsoptimized ;;
-  }
-
   dimension: product_ecu {
     hidden: yes
     type: string
@@ -359,69 +309,45 @@ view: cost_and_usage {
   dimension: endpoint_type {
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.product_endpointtype ;;
+    sql: ${TABLE}.product_endpoint_type ;;
   }
 
   dimension: engine_code {
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.product_enginecode ;;
+    sql: ${TABLE}.product_engine_code ;;
   }
 
   dimension: product_enhancednetworkingsupported {
     view_label: "Product Info"
     hidden: yes
     type: string
-    sql: ${TABLE}.product_enhancednetworkingsupported ;;
-  }
-
-  dimension: execution_frequency {
-    view_label: "Product Info"
-    type: string
-    sql: ${TABLE}.product_executionfrequency ;;
-  }
-
-  dimension: execution_location {
-    view_label: "Product Info"
-    type: string
-    sql: ${TABLE}.product_executionlocation ;;
+    sql: ${TABLE}.product_enhanced_networking_supported ;;
   }
 
   dimension: product_feecode {
     type: string
     hidden: yes
-    sql: ${TABLE}.product_feecode ;;
+    sql: ${TABLE}.product_fee_code ;;
   }
 
   dimension: product_feedescription {
     type: string
     hidden: yes
-    sql: ${TABLE}.product_feedescription ;;
+    sql: ${TABLE}.product_fee_description ;;
   }
 
   dimension: product_freequerytypes {
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.product_freequerytypes ;;
-  }
-
-  dimension: free_trial {
-    view_label: "Product Info"
-    type: string
-    sql: ${TABLE}.product_freetrial ;;
-  }
-
-  dimension: product_frequencymode {
-    hidden: yes
-    type: string
-    sql: ${TABLE}.product_frequencymode ;;
+    sql: ${TABLE}.product_free_query_types ;;
   }
 
   dimension: from_location {
     view_label: "Product Info"
     type: string
 #     map_layer_name: countries
-    sql: ${TABLE}.product_fromlocation ;;
+    sql: ${TABLE}.product_from_location ;;
   }
 
   dimension: from_location_viz {
@@ -445,24 +371,24 @@ view: cost_and_usage {
     hidden: yes
     type: string
     sql: CASE
-        WHEN ${TABLE}.product_fromlocation = 'Asia Pacific (Mumbai)' THEN '19.075984'
-        WHEN ${TABLE}.product_fromlocation = 'Asia Pacific (Seoul)' THEN '37.566535'
-        WHEN ${TABLE}.product_fromlocation = 'Asia Pacific (Singapore)' THEN '1.352083'
-        WHEN ${TABLE}.product_fromlocation = 'Asia Pacific (Sydney)' THEN '-33.868820'
-        WHEN ${TABLE}.product_fromlocation = 'Asia Pacific (Tokyo)' THEN '35.689487'
-        WHEN ${TABLE}.product_fromlocation = 'Australia' THEN '-25.274398'
-        WHEN ${TABLE}.product_fromlocation = 'Canada' THEN '56.130366'
-        WHEN ${TABLE}.product_fromlocation = 'Canada (Central)' THEN '56.130366'
-        WHEN ${TABLE}.product_fromlocation = 'EU (Frankfurt)' THEN '50.110922'
-        WHEN ${TABLE}.product_fromlocation = 'EU (Ireland)' THEN '53.142367'
-        WHEN ${TABLE}.product_fromlocation = 'India' THEN '20.593684'
-        WHEN ${TABLE}.product_fromlocation = 'Japan' THEN '36.204824'
-        WHEN ${TABLE}.product_fromlocation = 'South America (Sao Paulo)' THEN '-23.550520'
-        WHEN ${TABLE}.product_fromlocation = 'South America' THEN '-23.550520'
-        WHEN ${TABLE}.product_fromlocation = 'US East (N. Virginia)' THEN '37.431573'
-        WHEN ${TABLE}.product_fromlocation = 'US East (Ohio)' THEN '40.417287'
-        WHEN ${TABLE}.product_fromlocation = 'US West (N. California)' THEN '38.837522'
-        WHEN ${TABLE}.product_fromlocation = 'US WEST (Oregon)' THEN '43.804133'
+        WHEN ${TABLE}.product_from_location = 'Asia Pacific (Mumbai)' THEN '19.075984'
+        WHEN ${TABLE}.product_from_location = 'Asia Pacific (Seoul)' THEN '37.566535'
+        WHEN ${TABLE}.product_from_location = 'Asia Pacific (Singapore)' THEN '1.352083'
+        WHEN ${TABLE}.product_from_location = 'Asia Pacific (Sydney)' THEN '-33.868820'
+        WHEN ${TABLE}.product_from_location = 'Asia Pacific (Tokyo)' THEN '35.689487'
+        WHEN ${TABLE}.product_from_location = 'Australia' THEN '-25.274398'
+        WHEN ${TABLE}.product_from_location = 'Canada' THEN '56.130366'
+        WHEN ${TABLE}.product_from_location = 'Canada (Central)' THEN '56.130366'
+        WHEN ${TABLE}.product_from_location = 'EU (Frankfurt)' THEN '50.110922'
+        WHEN ${TABLE}.product_from_location = 'EU (Ireland)' THEN '53.142367'
+        WHEN ${TABLE}.product_from_location = 'India' THEN '20.593684'
+        WHEN ${TABLE}.product_from_location = 'Japan' THEN '36.204824'
+        WHEN ${TABLE}.product_from_location = 'South America (Sao Paulo)' THEN '-23.550520'
+        WHEN ${TABLE}.product_from_location = 'South America' THEN '-23.550520'
+        WHEN ${TABLE}.product_from_location = 'US East (N. Virginia)' THEN '37.431573'
+        WHEN ${TABLE}.product_from_location = 'US East (Ohio)' THEN '40.417287'
+        WHEN ${TABLE}.product_from_location = 'US West (N. California)' THEN '38.837522'
+        WHEN ${TABLE}.product_from_location = 'US WEST (Oregon)' THEN '43.804133'
         ELSE 'Not labeled'
         END
         ;;
@@ -472,24 +398,24 @@ view: cost_and_usage {
     hidden: yes
     type: string
     sql: CASE
-        WHEN ${TABLE}.product_fromlocation = 'Asia Pacific (Mumbai)' THEN '72.877656'
-        WHEN ${TABLE}.product_fromlocation = 'Asia Pacific (Seoul)' THEN '126.977969'
-        WHEN ${TABLE}.product_fromlocation = 'Asia Pacific (Singapore)' THEN '103.819836'
-        WHEN ${TABLE}.product_fromlocation = 'Asia Pacific (Sydney)' THEN '151.209296'
-        WHEN ${TABLE}.product_fromlocation = 'Asia Pacific (Tokyo)' THEN '139.691706'
-        WHEN ${TABLE}.product_fromlocation = 'Australia' THEN '133.775136'
-        WHEN ${TABLE}.product_fromlocation = 'Canada' THEN '-106.346771'
-        WHEN ${TABLE}.product_fromlocation = 'Canada (Central)' THEN '-106.346771'
-        WHEN ${TABLE}.product_fromlocation = 'EU (Frankfurt)' THEN '8.682127'
-        WHEN ${TABLE}.product_fromlocation = 'EU (Ireland)' THEN '-7.692054'
-        WHEN ${TABLE}.product_fromlocation = 'India' THEN '78.962880'
-        WHEN ${TABLE}.product_fromlocation = 'Japan' THEN '138.252924'
-        WHEN ${TABLE}.product_fromlocation = 'South America (Sao Paulo)' THEN '-46.633309'
-        WHEN ${TABLE}.product_fromlocation = 'South America' THEN '-46.633309'
-        WHEN ${TABLE}.product_fromlocation = 'US East (N. Virginia)' THEN '-78.656894'
-        WHEN ${TABLE}.product_fromlocation = 'US East (Ohio)' THEN '-82.907123'
-        WHEN ${TABLE}.product_fromlocation = 'US West (N. California)' THEN '-120.895824'
-        WHEN ${TABLE}.product_fromlocation = 'US West (Oregon)' THEN '-120.554201'
+        WHEN ${TABLE}.product_from_location = 'Asia Pacific (Mumbai)' THEN '72.877656'
+        WHEN ${TABLE}.product_from_location = 'Asia Pacific (Seoul)' THEN '126.977969'
+        WHEN ${TABLE}.product_from_location = 'Asia Pacific (Singapore)' THEN '103.819836'
+        WHEN ${TABLE}.product_from_location = 'Asia Pacific (Sydney)' THEN '151.209296'
+        WHEN ${TABLE}.product_from_location = 'Asia Pacific (Tokyo)' THEN '139.691706'
+        WHEN ${TABLE}.product_from_location = 'Australia' THEN '133.775136'
+        WHEN ${TABLE}.product_from_location = 'Canada' THEN '-106.346771'
+        WHEN ${TABLE}.product_from_location = 'Canada (Central)' THEN '-106.346771'
+        WHEN ${TABLE}.product_from_location = 'EU (Frankfurt)' THEN '8.682127'
+        WHEN ${TABLE}.product_from_location = 'EU (Ireland)' THEN '-7.692054'
+        WHEN ${TABLE}.product_from_location = 'India' THEN '78.962880'
+        WHEN ${TABLE}.product_from_location = 'Japan' THEN '138.252924'
+        WHEN ${TABLE}.product_from_location = 'South America (Sao Paulo)' THEN '-46.633309'
+        WHEN ${TABLE}.product_from_location = 'South America' THEN '-46.633309'
+        WHEN ${TABLE}.product_from_location = 'US East (N. Virginia)' THEN '-78.656894'
+        WHEN ${TABLE}.product_from_location = 'US East (Ohio)' THEN '-82.907123'
+        WHEN ${TABLE}.product_from_location = 'US West (N. California)' THEN '-120.895824'
+        WHEN ${TABLE}.product_from_location = 'US West (Oregon)' THEN '-120.554201'
         ELSE 'Not labeled'
         END
         ;;
@@ -500,27 +426,27 @@ view: cost_and_usage {
     hidden: yes
     type: string
     sql: CASE
-    WHEN ${TABLE}.product_tolocation = 'Asia Pacific (Mumbai)' OR ${TABLE}.product_tolocationtype = 'Asia Pacific (Mumbai)' THEN '19.075984'
-    WHEN ${TABLE}.product_tolocation = 'Asia Pacific (Seoul)' OR ${TABLE}.product_tolocationtype = 'Asia Pacific (Seoul)' THEN '37.566535'
-    WHEN ${TABLE}.product_tolocation = 'Asia Pacific (Singapore)' OR ${TABLE}.product_tolocationtype = 'Asia Pacific (Singapore)' THEN '1.352083'
-    WHEN ${TABLE}.product_tolocation = 'Asia Pacific (Sydney)' OR ${TABLE}.product_tolocationtype = 'Asia Pacific (Sydney)' THEN '-33.868820'
-    WHEN ${TABLE}.product_tolocation = 'Asia Pacific (Tokyo)' OR ${TABLE}.product_tolocationtype = 'Asia Pacific (Tokyo)' THEN '35.689487'
-    WHEN ${TABLE}.product_tolocation = 'Australia' OR ${TABLE}.product_tolocationtype = 'Australia' THEN '-25.274398'
-    WHEN ${TABLE}.product_tolocation = 'Canada' OR ${TABLE}.product_tolocationtype = 'Canada' THEN '56.130366'
-    WHEN ${TABLE}.product_tolocation = 'Canada (Central)' OR ${TABLE}.product_tolocationtype = 'Canada (Central)' THEN '56.130366'
-    WHEN ${TABLE}.product_tolocation = 'EU (Frankfurt)' OR ${TABLE}.product_tolocationtype = 'EU (Frankfurt)' THEN '50.110922'
-    WHEN ${TABLE}.product_tolocation = 'EU (Ireland)' OR ${TABLE}.product_tolocationtype = 'EU (Ireland)' THEN '53.142367'
-    WHEN ${TABLE}.product_tolocation = 'India' OR ${TABLE}.product_tolocationtype = 'India' THEN  '20.593684'
-    WHEN ${TABLE}.product_tolocation = 'Japan' OR ${TABLE}.product_tolocationtype = 'Japan' THEN '36.204824'
-    WHEN ${TABLE}.product_tolocation = 'South America (Sao Paulo)' OR ${TABLE}.product_tolocationtype = 'South America (Sao Paulo)' THEN '-23.550520'
-    WHEN ${TABLE}.product_tolocation = 'South America' OR ${TABLE}.product_tolocationtype = 'South America' THEN  '-23.550520'
-    WHEN ${TABLE}.product_tolocation = 'US East (N. Virginia)' OR ${TABLE}.product_tolocationtype = 'US East (N. Virginia)' THEN '37.431573'
-    WHEN ${TABLE}.product_tolocation = 'US East (Ohio)' OR ${TABLE}.product_tolocationtype = 'US East (Ohio)' THEN '40.417287'
-    WHEN ${TABLE}.product_tolocation = 'US West (N. California)' OR ${TABLE}.product_tolocationtype = 'US West (N. California)' THEN '38.837522'
-    WHEN ${TABLE}.product_tolocation = 'US WEST (Oregon)' OR ${TABLE}.product_tolocationtype = 'US WEST (Oregon)' THEN '43.804133'
-    ELSE 'Not labeled'
-    END
-        ;;
+          WHEN ${TABLE}.product_to_location = 'Asia Pacific (Mumbai)' OR ${TABLE}.product_to_location_type = 'Asia Pacific (Mumbai)' THEN '19.075984'
+          WHEN ${TABLE}.product_to_location = 'Asia Pacific (Seoul)' OR ${TABLE}.product_to_location_type = 'Asia Pacific (Seoul)' THEN '37.566535'
+          WHEN ${TABLE}.product_to_location = 'Asia Pacific (Singapore)' OR ${TABLE}.product_to_location_type = 'Asia Pacific (Singapore)' THEN '1.352083'
+          WHEN ${TABLE}.product_to_location = 'Asia Pacific (Sydney)' OR ${TABLE}.product_to_location_type = 'Asia Pacific (Sydney)' THEN '-33.868820'
+          WHEN ${TABLE}.product_to_location = 'Asia Pacific (Tokyo)' OR ${TABLE}.product_to_location_type = 'Asia Pacific (Tokyo)' THEN '35.689487'
+          WHEN ${TABLE}.product_to_location = 'Australia' OR ${TABLE}.product_to_location_type = 'Australia' THEN '-25.274398'
+          WHEN ${TABLE}.product_to_location = 'Canada' OR ${TABLE}.product_to_location_type = 'Canada' THEN '56.130366'
+          WHEN ${TABLE}.product_to_location = 'Canada (Central)' OR ${TABLE}.product_to_location_type = 'Canada (Central)' THEN '56.130366'
+          WHEN ${TABLE}.product_to_location = 'EU (Frankfurt)' OR ${TABLE}.product_to_location_type = 'EU (Frankfurt)' THEN '50.110922'
+          WHEN ${TABLE}.product_to_location = 'EU (Ireland)' OR ${TABLE}.product_to_location_type = 'EU (Ireland)' THEN '53.142367'
+          WHEN ${TABLE}.product_to_location = 'India' OR ${TABLE}.product_to_location_type = 'India' THEN  '20.593684'
+          WHEN ${TABLE}.product_to_location = 'Japan' OR ${TABLE}.product_to_location_type = 'Japan' THEN '36.204824'
+          WHEN ${TABLE}.product_to_location = 'South America (Sao Paulo)' OR ${TABLE}.product_to_location_type = 'South America (Sao Paulo)' THEN '-23.550520'
+          WHEN ${TABLE}.product_to_location = 'South America' OR ${TABLE}.product_to_location_type = 'South America' THEN  '-23.550520'
+          WHEN ${TABLE}.product_to_location = 'US East (N. Virginia)' OR ${TABLE}.product_to_location_type = 'US East (N. Virginia)' THEN '37.431573'
+          WHEN ${TABLE}.product_to_location = 'US East (Ohio)' OR ${TABLE}.product_to_location_type = 'US East (Ohio)' THEN '40.417287'
+          WHEN ${TABLE}.product_to_location = 'US West (N. California)' OR ${TABLE}.product_to_location_type = 'US West (N. California)' THEN '38.837522'
+          WHEN ${TABLE}.product_to_location = 'US WEST (Oregon)' OR ${TABLE}.product_to_location_type = 'US WEST (Oregon)' THEN '43.804133'
+          ELSE 'Not labeled'
+          END
+              ;;
   }
 
   dimension: to_location_long {
@@ -528,33 +454,33 @@ view: cost_and_usage {
     hidden: yes
     type: string
     sql: CASE
-    WHEN ${TABLE}.product_tolocation = 'Asia Pacific (Mumbai)' OR ${TABLE}.product_tolocationtype = 'Asia Pacific (Mumbai)' THEN '72.877656'
-    WHEN ${TABLE}.product_tolocation = 'Asia Pacific (Seoul)' OR  ${TABLE}.product_tolocationtype = 'Asia Pacific (Seoul)' THEN '126.977969'
-    WHEN ${TABLE}.product_tolocation = 'Asia Pacific (Singapore)' OR ${TABLE}.product_tolocationtype = 'Asia Pacific (Singapore)' THEN '103.819836'
-    WHEN ${TABLE}.product_tolocation = 'Asia Pacific (Sydney)' OR ${TABLE}.product_tolocationtype = 'Asia Pacific (Sydney)' THEN '151.209296'
-    WHEN ${TABLE}.product_tolocation = 'Asia Pacific (Tokyo)' OR ${TABLE}.product_tolocationtype = 'Asia Pacific (Tokyo)' THEN '139.691706'
-    WHEN ${TABLE}.product_tolocation = 'Australia' OR ${TABLE}.product_tolocationtype = 'Australia' THEN '133.775136'
-    WHEN ${TABLE}.product_tolocation = 'Canada' OR ${TABLE}.product_tolocationtype  = 'Canada' THEN  '-106.346771'
-    WHEN ${TABLE}.product_tolocation = 'Canada (Central)' OR ${TABLE}.product_tolocationtype = 'Canada (Central)' THEN '-106.346771'
-    WHEN ${TABLE}.product_tolocation = 'EU (Frankfurt)' OR ${TABLE}.product_tolocationtype = 'EU (Frankfurt)' THEN '8.682127'
-    WHEN ${TABLE}.product_tolocation = 'EU (Ireland)' OR ${TABLE}.product_tolocationtype = 'EU (Ireland)' THEN '-7.692054'
-    WHEN ${TABLE}.product_tolocation = 'India' OR ${TABLE}.product_tolocationtype = 'India' THEN '78.962880'
-    WHEN ${TABLE}.product_tolocation = 'Japan' OR ${TABLE}.product_tolocationtype = 'Japan' THEN '138.252924'
-    WHEN ${TABLE}.product_tolocation = 'South America (Sao Paulo)' OR ${TABLE}.product_tolocationtype = 'South America (Sao Paulo)' THEN '-46.633309'
-    WHEN ${TABLE}.product_tolocation = 'South America' OR ${TABLE}.product_tolocationtype = 'South America' THEN '-46.633309'
-    WHEN ${TABLE}.product_tolocation = 'US East (N. Virginia)' OR ${TABLE}.product_tolocationtype = 'US East (N. Virginia)' THEN '-78.656894'
-    WHEN ${TABLE}.product_tolocation = 'US East (Ohio)' OR ${TABLE}.product_tolocationtype = 'US East (Ohio)' THEN '-82.907123'
-    WHEN ${TABLE}.product_tolocation = 'US West (N. California)' OR ${TABLE}.product_tolocationtype = 'US West (N. California)' THEN '-120.895824'
-    WHEN ${TABLE}.product_tolocation = 'US West (Oregon)' OR ${TABLE}.product_tolocationtype = 'US West (Oregon)' THEN '-120.554201'
-    ELSE 'Not labeled'
-    END
-        ;;
+          WHEN ${TABLE}.product_to_location = 'Asia Pacific (Mumbai)' OR ${TABLE}.product_to_location_type = 'Asia Pacific (Mumbai)' THEN '72.877656'
+          WHEN ${TABLE}.product_to_location = 'Asia Pacific (Seoul)' OR  ${TABLE}.product_to_location_type = 'Asia Pacific (Seoul)' THEN '126.977969'
+          WHEN ${TABLE}.product_to_location = 'Asia Pacific (Singapore)' OR ${TABLE}.product_to_location_type = 'Asia Pacific (Singapore)' THEN '103.819836'
+          WHEN ${TABLE}.product_to_location = 'Asia Pacific (Sydney)' OR ${TABLE}.product_to_location_type = 'Asia Pacific (Sydney)' THEN '151.209296'
+          WHEN ${TABLE}.product_to_location = 'Asia Pacific (Tokyo)' OR ${TABLE}.product_to_location_type = 'Asia Pacific (Tokyo)' THEN '139.691706'
+          WHEN ${TABLE}.product_to_location = 'Australia' OR ${TABLE}.product_to_location_type = 'Australia' THEN '133.775136'
+          WHEN ${TABLE}.product_to_location = 'Canada' OR ${TABLE}.product_to_location_type  = 'Canada' THEN  '-106.346771'
+          WHEN ${TABLE}.product_to_location = 'Canada (Central)' OR ${TABLE}.product_to_location_type = 'Canada (Central)' THEN '-106.346771'
+          WHEN ${TABLE}.product_to_location = 'EU (Frankfurt)' OR ${TABLE}.product_to_location_type = 'EU (Frankfurt)' THEN '8.682127'
+          WHEN ${TABLE}.product_to_location = 'EU (Ireland)' OR ${TABLE}.product_to_location_type = 'EU (Ireland)' THEN '-7.692054'
+          WHEN ${TABLE}.product_to_location = 'India' OR ${TABLE}.product_to_location_type = 'India' THEN '78.962880'
+          WHEN ${TABLE}.product_to_location = 'Japan' OR ${TABLE}.product_to_location_type = 'Japan' THEN '138.252924'
+          WHEN ${TABLE}.product_to_location = 'South America (Sao Paulo)' OR ${TABLE}.product_to_location_type = 'South America (Sao Paulo)' THEN '-46.633309'
+          WHEN ${TABLE}.product_to_location = 'South America' OR ${TABLE}.product_to_location_type = 'South America' THEN '-46.633309'
+          WHEN ${TABLE}.product_to_location = 'US East (N. Virginia)' OR ${TABLE}.product_to_location_type = 'US East (N. Virginia)' THEN '-78.656894'
+          WHEN ${TABLE}.product_to_location = 'US East (Ohio)' OR ${TABLE}.product_to_location_type = 'US East (Ohio)' THEN '-82.907123'
+          WHEN ${TABLE}.product_to_location = 'US West (N. California)' OR ${TABLE}.product_to_location_type = 'US West (N. California)' THEN '-120.895824'
+          WHEN ${TABLE}.product_to_location = 'US West (Oregon)' OR ${TABLE}.product_to_location_type = 'US West (Oregon)' THEN '-120.554201'
+          ELSE 'Not labeled'
+          END
+              ;;
   }
 
   dimension: from_location_type {
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.product_fromlocationtype ;;
+    sql: ${TABLE}.product_from_location_type ;;
   }
 
   dimension: product_group {
@@ -566,25 +492,19 @@ view: cost_and_usage {
   dimension: group_description {
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.product_groupdescription ;;
-  }
-
-  dimension: product_includedservices {
-    hidden: yes
-    type: string
-    sql: ${TABLE}.product_includedservices ;;
+    sql: ${TABLE}.product_group_description ;;
   }
 
   dimension: product_instancefamily {
     type: string
     hidden: yes
-    sql: ${TABLE}.product_instancefamily ;;
+    sql: ${TABLE}.product_instance_family ;;
   }
 
   dimension: instance_type {
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.product_instancetype ;;
+    sql: ${TABLE}.product_instance_type ;;
   }
 
   dimension: product_io {
@@ -596,13 +516,13 @@ view: cost_and_usage {
   dimension: product_launchsupport {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_launchsupport ;;
+    sql: ${TABLE}.product_launch_support ;;
   }
 
   dimension: product_licensemodel {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_licensemodel ;;
+    sql: ${TABLE}.product_license_model ;;
   }
 
   dimension: location {
@@ -614,37 +534,31 @@ view: cost_and_usage {
   dimension: location_type {
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.product_locationtype ;;
-  }
-
-  dimension: product_maximumstoragevolume {
-    hidden: yes
-    type: string
-    sql: ${TABLE}.product_maximumstoragevolume ;;
+    sql: ${TABLE}.product_location_type ;;
   }
 
   dimension: product_maxiopsburstperformance {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_maxiopsburstperformance ;;
+    sql: ${TABLE}.product_max_iops_burst_performance ;;
   }
 
   dimension: product_maxiopsvolume {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_maxiopsvolume ;;
+    sql: ${TABLE}.product_max_iopsvolume ;;
   }
 
   dimension: max_throughput_volume {
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.product_maxthroughputvolume ;;
+    sql: ${TABLE}.product_max_throughputvolume ;;
   }
 
   dimension: product_maxvolumesize {
     type: string
     hidden: yes
-    sql: ${TABLE}.product_maxvolumesize ;;
+    sql: ${TABLE}.product_max_volume_size ;;
   }
 
   dimension: product_memory {
@@ -656,37 +570,31 @@ view: cost_and_usage {
   dimension: product_messagedeliveryfrequency {
     type: string
     hidden: yes
-    sql: ${TABLE}.product_messagedeliveryfrequency ;;
+    sql: ${TABLE}.product_message_delivery_frequency ;;
   }
 
   dimension: product_messagedeliveryorder {
     type: string
     hidden: yes
-    sql: ${TABLE}.product_messagedeliveryorder ;;
-  }
-
-  dimension: product_minimumstoragevolume {
-    type: string
-    hidden: yes
-    sql: ${TABLE}.product_minimumstoragevolume ;;
+    sql: ${TABLE}.product_message_delivery_order ;;
   }
 
   dimension: product_minvolumesize {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_minvolumesize ;;
+    sql: ${TABLE}.product_min_volume_size ;;
   }
 
   dimension: network_performance {
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.product_networkperformance ;;
+    sql: ${TABLE}.product_network_performance ;;
   }
 
   dimension: operating_system {
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.product_operatingsystem ;;
+    sql: ${TABLE}.product_operating_system ;;
   }
 
   dimension: product_operation {
@@ -699,44 +607,38 @@ view: cost_and_usage {
   dimension: product_operationssupport {
     type: string
     hidden: yes
-    sql: ${TABLE}.product_operationssupport ;;
+    sql: ${TABLE}.product_operations_support ;;
   }
 
   dimension: product_physicalprocessor {
     type: string
     hidden: yes
-    sql: ${TABLE}.product_physicalprocessor ;;
+    sql: ${TABLE}.product_physical_processor ;;
   }
 
   dimension: product_preinstalledsw {
     type: string
     hidden: yes
-    sql: ${TABLE}.product_preinstalledsw ;;
-  }
-
-  dimension: product_proactiveguidance {
-    type: string
-    hidden: yes
-    sql: ${TABLE}.product_proactiveguidance ;;
+    sql: ${TABLE}.product_pre_installed_sw ;;
   }
 
   dimension: product_processorarchitecture {
     type: string
     hidden: yes
-    sql: ${TABLE}.product_processorarchitecture ;;
+    sql: ${TABLE}.product_processor_architecture ;;
   }
 
   dimension: product_processorfeatures {
     type: string
     hidden: yes
-    sql: ${TABLE}.product_processorfeatures ;;
+    sql: ${TABLE}.product_processor_features ;;
   }
 
   dimension: productfamily {
     label: "Family"
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.product_productfamily ;;
+    sql: ${TABLE}.product_product_family ;;
   }
 
 
@@ -747,15 +649,10 @@ view: cost_and_usage {
     description: "Innaccurate labeling on part of AWS - use product code instead"
     hidden: yes
     view_label: "Product Info"
-    sql: ${TABLE}.product_productname ;;
+    sql: ${TABLE}.product_product_name ;;
   }
 
 #####
-  dimension: product_programmaticcasemanagement {
-    hidden: yes
-    type: string
-    sql: ${TABLE}.product_programmaticcasemanagement ;;
-  }
 
   dimension: product_provisioned {
     hidden: yes
@@ -766,37 +663,37 @@ view: cost_and_usage {
   dimension: product_queuetype {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_queuetype ;;
+    sql: ${TABLE}.product_queue_type ;;
   }
 
   dimension: product_requestdescription {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_requestdescription ;;
+    sql: ${TABLE}.product_request_description ;;
   }
 
   dimension: product_requesttype {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_requesttype ;;
+    sql: ${TABLE}.product_request_type ;;
   }
 
   dimension: product_routingtarget {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_routingtarget ;;
+    sql: ${TABLE}.product_routing_target ;;
   }
 
   dimension: product_routingtype {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_routingtype ;;
+    sql: ${TABLE}.product_routing_type ;;
   }
 
   dimension: product_servicecode {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_servicecode ;;
+    sql: ${TABLE}.product_service_code ;;
   }
 
   dimension: product_sku {
@@ -820,19 +717,13 @@ view: cost_and_usage {
   dimension: product_storageclass {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_storageclass ;;
+    sql: ${TABLE}.product_storage_class ;;
   }
 
   dimension: product_storagemedia {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_storagemedia ;;
-  }
-
-  dimension: product_technicalsupport {
-    hidden: yes
-    type: string
-    sql: ${TABLE}.product_technicalsupport ;;
+    sql: ${TABLE}.product_storage_media ;;
   }
 
   dimension: tenancy {
@@ -841,41 +732,31 @@ view: cost_and_usage {
     sql: ${TABLE}.product_tenancy ;;
   }
 
-  dimension: product_thirdpartysoftwaresupport {
-    hidden: yes
-    type: string
-    sql: ${TABLE}.product_thirdpartysoftwaresupport ;;
-  }
 
   dimension: to_location {
     view_label: "Product Info"
 #     map_layer_name: countries
     type: string
-    sql: ${TABLE}.product_tolocation ;;
+    sql: ${TABLE}.product_to_location ;;
   }
 
   dimension: to_location_type {
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.product_tolocationtype ;;
+    sql: ${TABLE}.product_to_location_type ;;
   }
 
-  dimension: training {
-    view_label: "Product Info"
-    type: string
-    sql: ${TABLE}.product_training ;;
-  }
 
   dimension: transfer_type {
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.product_transfertype ;;
+    sql: ${TABLE}.product_transfer_type ;;
   }
 
   dimension: usage_family {
     view_label: "Product Info"
     type: string
-    sql: ${TABLE}.product_usagefamily ;;
+    sql: ${TABLE}.product_usage_family ;;
   }
 
   dimension: data_transfer {
@@ -917,43 +798,38 @@ view: cost_and_usage {
   dimension: product_volumetype {
     type: string
     hidden: yes
-    sql: ${TABLE}.product_volumetype ;;
+    sql: ${TABLE}.product_volume_type ;;
   }
 
-  dimension: product_whocanopencases {
-    hidden: yes
-    type: string
-    sql: ${TABLE}.product_whocanopencases ;;
-  }
 
   dimension: pricing_leasecontractlength {
     hidden: yes
     type: string
-    sql: ${TABLE}.pricing_leasecontractlength ;;
+    sql: ${TABLE}.pricing_lease_contract_length ;;
   }
 
   dimension: pricing_offeringclass {
     hidden: yes
     type: string
-    sql: ${TABLE}.product_storageclass ;;
+    sql: ${TABLE}.pricing_offering_class ;;
   }
 
   dimension: pricing_purchaseoption {
     hidden: yes
     type: string
-    sql: ${TABLE}.pricing_purchaseoption ;;
+    sql: ${TABLE}.pricing_purchase_option ;;
   }
 
   dimension: pricing_publicondemandcost {
     hidden: yes
     type: string
-    sql: ${TABLE}.pricing_publicondemandcost ;;
+    sql: ${TABLE}.pricing_public_on_demand_cost ;;
   }
 
   dimension: pricing_publicondemandrate {
     hidden: yes
     type: string
-    sql: ${TABLE}.pricing_publicondemandrate ;;
+    sql: ${TABLE}.pricing_public_on_demand_rate ;;
   }
 
   dimension: pricing_term {
@@ -971,32 +847,32 @@ view: cost_and_usage {
   dimension: reservation_availabilityzone {
     hidden: yes
     type: string
-    sql: ${TABLE}.reservation_availabilityzone ;;
+    sql: ${TABLE}.reservation_availability_zone ;;
   }
 
   dimension: reservation_unitsperreservation {
     type: string
     hidden: yes
-    sql: ${TABLE}.reservation_normalizedunitsperreservation ;;
+    sql: ${TABLE}.reservation_normalized_units_per_reservation ;;
   }
 
   dimension: reservation_numberofreservations {
     type: number
     hidden: yes
-    sql: ${TABLE}.reservation_numberofreservations ;;
+    sql: ${TABLE}.reservation_number_of_reservations ;;
   }
 
   dimension: reservation_arn {
     view_label: "Reserved Units"
     description: "When an RI benefit discount is applied to a matching line item of usage, the ARN value in the reservation/ReservationARN column for the initial upfront fees and recurring monthly charges matches the ARN value in the discounted usage line items."
     type: string
-    sql: ${TABLE}.reservation_reservationarn ;;
+    sql: ${TABLE}.reservation_reservation_a_r_n ;;
   }
 
   dimension: reservation_totalreservednormalizedunits {
     hidden: yes
     type: string
-    sql: ${TABLE}.reservation_totalreservednormalizedunits ;;
+    sql: ${TABLE}.reservation_total_reserved_normalized_units ;;
   }
 
   dimension: reservation_totalreservedunits {
@@ -1004,36 +880,13 @@ view: cost_and_usage {
     description: "The total number of total number of hours across all reserved instances in the subscription."
     type: number
     hidden: yes
-    sql: ${TABLE}.reservation_totalreservedunits ;;
+    sql: ${TABLE}.reservation_total_reserved_units ;;
   }
 
 
 
   ### ENABLE FOR CUSTOM TAGS ###
 
-  dimension: user_name {
-    view_label: "Custom Resource Tagging"
-    type: string
-    sql: ${TABLE}.resourcetags_username ;;
-  }
-
-  dimension: user_cost_category {
-    view_label: "Custom Resource Tagging"
-    type: string
-    sql: ${TABLE}.resourcetags_usercostcategory ;;
-  }
-
-  dimension: customer_segment {
-    view_label: "Custom Resource Tagging"
-    type: string
-    sql: CASE
-          WHEN ${user_cost_category} = '744.00000000' THEN 'SMB'
-          WHEN ${user_cost_category} = '' THEN 'Mid-Market'
-          WHEN ${user_cost_category} = 'internal' THEN 'Enterprise'
-          ELSE 'Enterprise'
-          END
-          ;;
-  }
 
   ### END EMNABLE FOR CUSTOM TAGS ###
 
@@ -1230,274 +1083,274 @@ view: cost_and_usage {
 
   measure: count_usage_months {
 #     hidden: yes
-    type: count_distinct
-    sql: ${usage_start_month} ;;
-    drill_fields: [billing_period_start_month, total_measures*]
+  type: count_distinct
+  sql: ${usage_start_month} ;;
+  drill_fields: [billing_period_start_month, total_measures*]
+}
+
+measure: average_blended_cost_all_time {
+  view_label: "Line Items (Individual Charges)"
+  description: "How much all aggregated line items are charged to a consolidated billing account in an organization"
+  type: average
+  sql: ${lineitem_blendedcost} ;;
+  value_format_name: usd
+  drill_fields: [common*, basic_blended_measures*]
+}
+
+measure: average_blended_cost_per_month {
+  view_label: "Line Items (Individual Charges)"
+  description: "How much all aggregated line items are charged to a consolidated billing account in an organization"
+  type: number
+  sql: ${total_blended_cost}/NULLIF(${count_usage_months},0) ;;
+  value_format_name: usd_0
+  link: {
+    label: "Explore Total Blended Cost"
+    url: "{{total_blended_cost._link}}"
   }
-
-  measure: average_blended_cost_all_time {
-    view_label: "Line Items (Individual Charges)"
-    description: "How much all aggregated line items are charged to a consolidated billing account in an organization"
-    type: average
-    sql: ${lineitem_blendedcost} ;;
-    value_format_name: usd
-    drill_fields: [common*, basic_blended_measures*]
+  link: {
+    label: "Explore Months"
+    url: "{{count_usage_months._link}}"
   }
+}
 
-  measure: average_blended_cost_per_month {
-    view_label: "Line Items (Individual Charges)"
-    description: "How much all aggregated line items are charged to a consolidated billing account in an organization"
-    type: number
-    sql: ${total_blended_cost}/NULLIF(${count_usage_months},0) ;;
-    value_format_name: usd_0
-    link: {
-      label: "Explore Total Blended Cost"
-      url: "{{total_blended_cost._link}}"
-    }
-    link: {
-      label: "Explore Months"
-      url: "{{count_usage_months._link}}"
-    }
+measure: average_blended_rate {
+  label: "Blended Rate"
+  view_label: "Line Items (Individual Charges)"
+  description: "The average rate applied to all aggregated line items for a consolidated billing account in an organization."
+  type: average
+  sql: ${blended_rate} ;;
+  value_format_name: usd
+  drill_fields: [common*, basic_blended_measures*]
+}
+
+measure: total_usage_amount {
+  view_label: "Line Items (Individual Charges)"
+  description: "The amount of usage incurred by the customer. For all reserved units, use the Total Reserved Units column instead."
+  type: sum
+  sql: ${lineitem_usageamount} ;;
+  value_format_name: decimal_0
+  drill_fields: [common*, basic_blended_measures*]
+}
+
+### PRODUCT SPECIFIC COST MEASURES ###
+
+measure: EC2_usage_amount {
+  label: "EC2 Usage Amount"
+  view_label: "Product Info"
+  type: sum
+  sql: ${lineitem_usageamount} ;;
+  filters: {
+    field: product_code
+    value: "AmazonEC2"
   }
+  drill_fields: [common*, EC2_usage_amount, ec2_measures*]
+}
 
-  measure: average_blended_rate {
-    label: "Blended Rate"
-    view_label: "Line Items (Individual Charges)"
-    description: "The average rate applied to all aggregated line items for a consolidated billing account in an organization."
-    type: average
-    sql: ${blended_rate} ;;
-    value_format_name: usd
-    drill_fields: [common*, basic_blended_measures*]
+measure: cloudfront_usage_amount {
+  view_label: "Product Info"
+  type: sum
+  sql: ${lineitem_usageamount} ;;
+  filters: {
+    field: product_code
+    value: "AmazonCloudFront"
   }
+  drill_fields: [common*, cloudfront_usage_amount]
+}
 
-  measure: total_usage_amount {
-    view_label: "Line Items (Individual Charges)"
-    description: "The amount of usage incurred by the customer. For all reserved units, use the Total Reserved Units column instead."
-    type: sum
-    sql: ${lineitem_usageamount} ;;
-    value_format_name: decimal_0
-    drill_fields: [common*, basic_blended_measures*]
+measure: cloudtrail_usage_amount {
+  view_label: "Product Info"
+  type: sum
+  sql: ${lineitem_usageamount} ;;
+  filters: {
+    field: product_code
+    value: "AWSCloudTrail"
   }
-
-  ### PRODUCT SPECIFIC COST MEASURES ###
-
-  measure: EC2_usage_amount {
-    label: "EC2 Usage Amount"
-    view_label: "Product Info"
-    type: sum
-    sql: ${lineitem_usageamount} ;;
-    filters: {
-      field: product_code
-      value: "AmazonEC2"
-    }
-    drill_fields: [common*, EC2_usage_amount, ec2_measures*]
+  drill_fields: [common*, cloudtrail_usage_amount]
+}
+measure: S3_usage_amount {
+  view_label: "Product Info"
+  type: sum
+  sql: ${lineitem_usageamount} ;;
+  filters: {
+    field: product_code
+    value: "AmazonS3"
   }
+  drill_fields: [common*, S3_usage_amount]
+}
 
-  measure: cloudfront_usage_amount {
-    view_label: "Product Info"
-    type: sum
-    sql: ${lineitem_usageamount} ;;
-    filters: {
-      field: product_code
-      value: "AmazonCloudFront"
-    }
-    drill_fields: [common*, cloudfront_usage_amount]
+measure: redshift_usage_amount {
+  view_label: "Product Info"
+  type: sum
+  sql: ${lineitem_usageamount} ;;
+  filters: {
+    field: product_code
+    value: "AmazonRedshift"
   }
+  drill_fields: [common*, redshift_usage_amount]
+}
 
-  measure: cloudtrail_usage_amount {
-    view_label: "Product Info"
-    type: sum
-    sql: ${lineitem_usageamount} ;;
-    filters: {
-      field: product_code
-      value: "AWSCloudTrail"
-    }
-    drill_fields: [common*, cloudtrail_usage_amount]
+measure: rds_usage_amount {
+  label: "RDS Usage Amount"
+  view_label: "Product Info"
+  type: sum
+  sql: ${lineitem_usageamount} ;;
+  filters: {
+    field: product_code
+    value: "AmazonRDS"
   }
-  measure: S3_usage_amount {
-    view_label: "Product Info"
-    type: sum
-    sql: ${lineitem_usageamount} ;;
-    filters: {
-      field: product_code
-      value: "AmazonS3"
-    }
-    drill_fields: [common*, S3_usage_amount]
+  drill_fields: [common*, rds_usage_amount]
+}
+
+measure: EC2_blended_cost {
+  label: "EC2 Blended Cost"
+  view_label: "Product Info"
+  type: sum
+  sql: ${lineitem_blendedcost} ;;
+  value_format_name: usd_0
+  filters: {
+    field: product_code
+    value: "AmazonEC2"
   }
+  drill_fields: [common*, EC2_blended_cost, ec2_measures*]
+}
 
-  measure: redshift_usage_amount {
-    view_label: "Product Info"
-    type: sum
-    sql: ${lineitem_usageamount} ;;
-    filters: {
-      field: product_code
-      value: "AmazonRedshift"
-    }
-    drill_fields: [common*, redshift_usage_amount]
+measure: EC2_reserved_blended_cost {
+  label: "EC2 Reserved Blended Cost"
+  view_label: "Product Info"
+  type: sum
+  sql: ${lineitem_blendedcost} ;;
+  value_format_name: usd_0
+  filters: {
+    field: product_code
+    value: "AmazonEC2"
   }
-
-  measure: rds_usage_amount {
-    label: "RDS Usage Amount"
-    view_label: "Product Info"
-    type: sum
-    sql: ${lineitem_usageamount} ;;
-    filters: {
-      field: product_code
-      value: "AmazonRDS"
-    }
-    drill_fields: [common*, rds_usage_amount]
+  filters: {
+    field: ri_line_item
+    value: "RI Line Item"
   }
+  drill_fields: [common*, EC2_reserved_blended_cost, ec2_measures*]
+}
 
-  measure: EC2_blended_cost {
-    label: "EC2 Blended Cost"
-    view_label: "Product Info"
-    type: sum
-    sql: ${lineitem_blendedcost} ;;
-    value_format_name: usd_0
-    filters: {
-      field: product_code
-      value: "AmazonEC2"
-    }
-    drill_fields: [common*, EC2_blended_cost, ec2_measures*]
+measure: EC2_non_reserved_blended_cost {
+  label: "EC2 Non Reserved Blended Cost"
+  view_label: "Product Info"
+  type: sum
+  sql: ${lineitem_blendedcost} ;;
+  value_format_name: usd_0
+  filters: {
+    field: product_code
+    value: "AmazonEC2"
   }
-
-  measure: EC2_reserved_blended_cost {
-    label: "EC2 Reserved Blended Cost"
-    view_label: "Product Info"
-    type: sum
-    sql: ${lineitem_blendedcost} ;;
-    value_format_name: usd_0
-    filters: {
-      field: product_code
-      value: "AmazonEC2"
-    }
-    filters: {
-      field: ri_line_item
-      value: "RI Line Item"
-    }
-    drill_fields: [common*, EC2_reserved_blended_cost, ec2_measures*]
+  filters: {
+    field: ri_line_item
+    value: "Non RI Line Item"
   }
+  drill_fields: [common*, EC2_non_reserved_blended_cost, ec2_measures*]
+}
 
-  measure: EC2_non_reserved_blended_cost {
-    label: "EC2 Non Reserved Blended Cost"
-    view_label: "Product Info"
-    type: sum
-    sql: ${lineitem_blendedcost} ;;
-    value_format_name: usd_0
-    filters: {
-      field: product_code
-      value: "AmazonEC2"
-    }
-    filters: {
-      field: ri_line_item
-      value: "Non RI Line Item"
-    }
-    drill_fields: [common*, EC2_non_reserved_blended_cost, ec2_measures*]
+measure: cloudfront_blended_cost {
+  view_label: "Product Info"
+  type: sum
+  sql: ${lineitem_blendedcost} ;;
+  value_format_name: usd_0
+  filters: {
+    field: product_code
+    value: "AmazonCloudFront"
   }
+  drill_fields: [common*, cloudtrail_blended_cost]
+}
 
-  measure: cloudfront_blended_cost {
-    view_label: "Product Info"
-    type: sum
-    sql: ${lineitem_blendedcost} ;;
-    value_format_name: usd_0
-    filters: {
-      field: product_code
-      value: "AmazonCloudFront"
-    }
-    drill_fields: [common*, cloudtrail_blended_cost]
+measure: cloudtrail_blended_cost {
+  view_label: "Product Info"
+  type: sum
+  sql: ${lineitem_blendedcost} ;;
+  value_format_name: usd_0
+  filters: {
+    field: product_code
+    value: "AWSCloudTrail"
   }
-
-  measure: cloudtrail_blended_cost {
-    view_label: "Product Info"
-    type: sum
-    sql: ${lineitem_blendedcost} ;;
-    value_format_name: usd_0
-    filters: {
-      field: product_code
-      value: "AWSCloudTrail"
-    }
-    drill_fields: [common*, cloudtrail_blended_cost]
+  drill_fields: [common*, cloudtrail_blended_cost]
+}
+measure: S3_blended_cost {
+  view_label: "Product Info"
+  type: sum
+  sql: ${lineitem_blendedcost} ;;
+  value_format_name: usd_0
+  filters: {
+    field: product_code
+    value: "AmazonS3"
   }
-  measure: S3_blended_cost {
-    view_label: "Product Info"
-    type: sum
-    sql: ${lineitem_blendedcost} ;;
-    value_format_name: usd_0
-    filters: {
-      field: product_code
-      value: "AmazonS3"
-    }
-    drill_fields: [common*, S3_blended_cost]
+  drill_fields: [common*, S3_blended_cost]
+}
+
+measure: redshift_blended_cost {
+  view_label: "Product Info"
+  type: sum
+  sql: ${lineitem_blendedcost} ;;
+  value_format_name: usd_0
+  filters: {
+    field: product_code
+    value: "AmazonRedshift"
   }
+  drill_fields: [common*, redshift_blended_cost]
+}
 
-  measure: redshift_blended_cost {
-    view_label: "Product Info"
-    type: sum
-    sql: ${lineitem_blendedcost} ;;
-    value_format_name: usd_0
-    filters: {
-      field: product_code
-      value: "AmazonRedshift"
-    }
-    drill_fields: [common*, redshift_blended_cost]
+measure: rds_blended_cost {
+  label: "RDS Blended Cost"
+  view_label: "Product Info"
+  type: sum
+  sql: ${lineitem_blendedcost} ;;
+  value_format_name: usd_0
+  filters: {
+    field: product_code
+    value: "AmazonRDS"
   }
-
-  measure: rds_blended_cost {
-    label: "RDS Blended Cost"
-    view_label: "Product Info"
-    type: sum
-    sql: ${lineitem_blendedcost} ;;
-    value_format_name: usd_0
-    filters: {
-      field: product_code
-      value: "AmazonRDS"
-    }
-    drill_fields: [common*, rds_blended_cost]
-  }
+  drill_fields: [common*, rds_blended_cost]
+}
 
 
 
-  ### RESERVED UNIT AGGREGATIONS ###
+### RESERVED UNIT AGGREGATIONS ###
 
-  measure: number_of_reservations {
-    view_label: "Reserved Units"
-    description: "The number of reservations covered by this subscription. For example, one Reserved Instance (RI) subscription may have four associated RI reservations."
-    type: sum
-    sql: ${reservation_numberofreservations} ;;
-    drill_fields: [common*, number_of_reservations, total_measures*]
-  }
+measure: number_of_reservations {
+  view_label: "Reserved Units"
+  description: "The number of reservations covered by this subscription. For example, one Reserved Instance (RI) subscription may have four associated RI reservations."
+  type: sum
+  sql: ${reservation_numberofreservations} ;;
+  drill_fields: [common*, number_of_reservations, total_measures*]
+}
 
 ### UNTIL DISCREPENCY IS RESOLVED, USING A MANUAL CALCULATION
-  measure: total_reserved_units_usage {
-    label: "Total Reserved Unit Usage (Hours Used)"
-    view_label: "Reserved Units"
-    description: "The total number of hours across all reserved instances in the subscription."
-    type: number
-    sql: (COALESCE(SUM(cost_and_usage_raw.reservation_numberofreservations),0) * COALESCE(SUM(cost_and_usage_raw.reservation_normalizedunitsperreservation),0 ) );;
-    drill_fields: [common*, total_reserved_units_usage, total_measures*]
-  }
+measure: total_reserved_units_usage {
+  label: "Total Reserved Unit Usage (Hours Used)"
+  view_label: "Reserved Units"
+  description: "The total number of hours across all reserved instances in the subscription."
+  type: number
+  sql: (COALESCE(SUM(cost_and_usage_raw.reservation_numberofreservations),0) * COALESCE(SUM(cost_and_usage_raw.reservation_normalizedunitsperreservation),0 ) );;
+  drill_fields: [common*, total_reserved_units_usage, total_measures*]
+}
 
-  measure: total_normalized_reserved_units {
-    view_label: "Reserved Units"
-    description: "The value for Usage Amount multiplied by the value for Normalization Factor"
-    type: sum
-    sql: ${reservation_totalreservednormalizedunits} ;;
-    drill_fields: [common*, total_normalized_reserved_units, total_measures*]
-  }
+measure: total_normalized_reserved_units {
+  view_label: "Reserved Units"
+  description: "The value for Usage Amount multiplied by the value for Normalization Factor"
+  type: sum
+  sql: ${reservation_totalreservednormalizedunits} ;;
+  drill_fields: [common*, total_normalized_reserved_units, total_measures*]
+}
 
-  measure: units_per_reservation {
-    label: "Units per Reservation (Hours Reserved)"
-    view_label: "Reserved Units"
-    description: "The number of usage units reserved by a single reservation in a given subscription, such as how many hours a single Amazon EC2 RI has reserved."
-    type: sum
-    sql: ${reservation_unitsperreservation} ;;
-    drill_fields: [common*, units_per_reservation, total_measures*]
-  }
+measure: units_per_reservation {
+  label: "Units per Reservation (Hours Reserved)"
+  view_label: "Reserved Units"
+  description: "The number of usage units reserved by a single reservation in a given subscription, such as how many hours a single Amazon EC2 RI has reserved."
+  type: sum
+  sql: ${reservation_unitsperreservation} ;;
+  drill_fields: [common*, units_per_reservation, total_measures*]
+}
 
-  set: common {fields: [lineitem_resourceid, line_item_operation,   type, bill_payeraccountid, description]}
-  set: total_measures {fields: [total_data_transfer_cost_unblended, total_data_transfer_cost, total_blended_cost, total_unblended_cost]  }
-  set: inbound_outbound {fields: [total_data_transfer_cost_unblended, total_data_transfer_cost, total_outbound_data_transfer_cost, total_inbound_data_transfer_cost]}
-  set: basic_blended_measures {fields: [average_blended_cost_per_month, average_blended_rate, total_usage_amount]}
-  set: ec2_measures {fields: [EC2_blended_cost,EC2_reserved_blended_cost,EC2_non_reserved_blended_cost,EC2_usage_amount]}
+set: common {fields: [lineitem_resourceid, line_item_operation,   type, bill_payeraccountid, description]}
+set: total_measures {fields: [total_data_transfer_cost_unblended, total_data_transfer_cost, total_blended_cost, total_unblended_cost]  }
+set: inbound_outbound {fields: [total_data_transfer_cost_unblended, total_data_transfer_cost, total_outbound_data_transfer_cost, total_inbound_data_transfer_cost]}
+set: basic_blended_measures {fields: [average_blended_cost_per_month, average_blended_rate, total_usage_amount]}
+set: ec2_measures {fields: [EC2_blended_cost,EC2_reserved_blended_cost,EC2_non_reserved_blended_cost,EC2_usage_amount]}
 
 }


### PR DESCRIPTION
CUR report schema reference:

```
CREATE EXTERNAL TABLE cur_report(
	identity_line_item_id STRING,
	identity_time_interval STRING,
	bill_invoice_id STRING,
	bill_billing_entity STRING,
	bill_bill_type STRING,
	bill_payer_account_id STRING,
	bill_billing_period_start_date TIMESTAMP,
	bill_billing_period_end_date TIMESTAMP,
	line_item_usage_account_id STRING,
	line_item_line_item_type STRING,
	line_item_usage_start_date TIMESTAMP,
	line_item_usage_end_date TIMESTAMP,
	line_item_product_code STRING,
	line_item_usage_type STRING,
	line_item_operation STRING,
	line_item_availability_zone STRING,
	line_item_resource_id STRING,
	line_item_usage_amount DOUBLE,
	line_item_normalization_factor DOUBLE,
	line_item_normalized_usage_amount DOUBLE,
	line_item_currency_code STRING,
	line_item_unblended_rate STRING,
	line_item_unblended_cost DOUBLE,
	line_item_blended_rate STRING,
	line_item_blended_cost DOUBLE,
	line_item_line_item_description STRING,
	line_item_tax_type STRING,
	line_item_net_unblended_rate STRING,
	line_item_net_unblended_cost DOUBLE,
	line_item_legal_entity STRING,
	product_product_name STRING,
	product_alarm_type STRING,
	product_attachment_type STRING,
	product_availability STRING,
	product_availability_zone STRING,
	product_cache_engine STRING,
	product_cache_memory_size_gb STRING,
	product_capacitystatus STRING,
	product_category STRING,
	product_clock_speed STRING,
	product_content_type STRING,
	product_cputype STRING,
	product_current_generation STRING,
	product_database_engine STRING,
	product_dedicated_ebs_throughput STRING,
	product_deployment_option STRING,
	product_description STRING,
	product_durability STRING,
	product_ecu STRING,
	product_edition STRING,
	product_endpoint_type STRING,
	product_engine_code STRING,
	product_enhanced_networking_supported STRING,
	product_event_type STRING,
	product_fee_code STRING,
	product_fee_description STRING,
	product_finding_group STRING,
	product_finding_source STRING,
	product_finding_storage STRING,
	product_free_query_types STRING,
	product_from_location STRING,
	product_from_location_type STRING,
	product_gpu STRING,
	product_gpu_memory STRING,
	product_group STRING,
	product_group_description STRING,
	product_instance_family STRING,
	product_instance_type STRING,
	product_instance_type_family STRING,
	product_intel_avx2_available STRING,
	product_intel_avx_available STRING,
	product_intel_turbo_available STRING,
	product_io STRING,
	product_license_model STRING,
	product_location STRING,
	product_location_type STRING,
	product_max_iops_burst_performance STRING,
	product_max_iopsvolume STRING,
	product_max_throughputvolume STRING,
	product_max_volume_size STRING,
	product_maximum_extended_storage STRING,
	product_memory STRING,
	product_memory_gib STRING,
	product_memorytype STRING,
	product_message_delivery_frequency STRING,
	product_message_delivery_order STRING,
	product_min_volume_size STRING,
	product_network_performance STRING,
	product_normalization_size_factor STRING,
	product_operating_system STRING,
	product_operation STRING,
	product_origin STRING,
	product_parameter_type STRING,
	product_physical_cpu STRING,
	product_physical_gpu STRING,
	product_physical_processor STRING,
	product_pre_installed_sw STRING,
	product_processor_architecture STRING,
	product_processor_features STRING,
	product_product_family STRING,
	product_provisioned STRING,
	product_queue_type STRING,
	product_recipient STRING,
	product_region STRING,
	product_request_description STRING,
	product_request_type STRING,
	product_resource_endpoint STRING,
	product_routing_target STRING,
	product_routing_type STRING,
	product_servicecode STRING,
	product_servicename STRING,
	product_sku STRING,
	product_software_type STRING,
	product_standard_group STRING,
	product_standard_source STRING,
	product_standard_storage STRING,
	product_standard_storage_retention_included STRING,
	product_storage STRING,
	product_storage_class STRING,
	product_storage_media STRING,
	product_storage_type STRING,
	product_subscription_type STRING,
	product_tenancy STRING,
	product_throughput STRING,
	product_tiertype STRING,
	product_to_location STRING,
	product_to_location_type STRING,
	product_transfer_type STRING,
	product_usage_family STRING,
	product_usagetype STRING,
	product_vcpu STRING,
	product_version STRING,
	product_volume_api_name STRING,
	product_volume_type STRING,
	pricing_lease_contract_length STRING,
	pricing_offering_class STRING,
	pricing_purchase_option STRING,
	pricing_rate_id STRING,
	pricing_public_on_demand_cost DOUBLE,
	pricing_public_on_demand_rate STRING,
	pricing_term STRING,
	pricing_unit STRING,
	reservation_amortized_upfront_cost_for_usage DOUBLE,
	reservation_amortized_upfront_fee_for_billing_period DOUBLE,
	reservation_availability_zone STRING,
	reservation_effective_cost DOUBLE,
	reservation_end_time STRING,
	reservation_modification_status STRING,
	reservation_net_amortized_upfront_cost_for_usage DOUBLE,
	reservation_net_amortized_upfront_fee_for_billing_period DOUBLE,
	reservation_net_effective_cost DOUBLE,
	reservation_net_recurring_fee_for_usage DOUBLE,
	reservation_net_unused_amortized_upfront_fee_for_billing_period DOUBLE,
	reservation_net_unused_recurring_fee DOUBLE,
	reservation_net_upfront_value DOUBLE,
	reservation_normalized_units_per_reservation STRING,
	reservation_number_of_reservations STRING,
	reservation_recurring_fee_for_usage DOUBLE,
	reservation_reservation_a_r_n STRING,
	reservation_start_time STRING,
	reservation_subscription_id STRING,
	reservation_total_reserved_normalized_units STRING,
	reservation_total_reserved_units STRING,
	reservation_units_per_reservation STRING,
	reservation_unused_amortized_upfront_fee_for_billing_period DOUBLE,
	reservation_unused_normalized_unit_quantity DOUBLE,
	reservation_unused_quantity DOUBLE,
	reservation_unused_recurring_fee DOUBLE,
	reservation_upfront_value DOUBLE,
	discount_edp_discount DOUBLE,
	discount_total_discount DOUBLE,
	savings_plan_total_commitment_to_date DOUBLE,
	savings_plan_savings_plan_a_r_n STRING,
	savings_plan_savings_plan_rate DOUBLE,
	savings_plan_used_commitment DOUBLE,
	savings_plan_savings_plan_effective_cost DOUBLE,
	savings_plan_amortized_upfront_commitment_for_billing_period DOUBLE,
	savings_plan_recurring_commitment_for_billing_period DOUBLE,
	savings_plan_net_savings_plan_effective_cost DOUBLE,
	savings_plan_net_amortized_upfront_commitment_for_billing_period DOUBLE,
	savings_plan_net_recurring_commitment_for_billing_period DOUBLE,
	resource_tags_aws_created_by STRING,
	resource_tags_aws_ecs_service_name STRING,
	resource_tags_user_mup_cluster STRING,
	resource_tags_user_mup_owner STRING,
	resource_tags_user_mup_product_name STRING,
	resource_tags_user_mup_stage STRING,
	resource_tags_user_mup_type STRING,
	resource_tags_user_product_name STRING
)
PARTITIONED BY (
	year STRING,
	month STRING
)
ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
WITH  SERDEPROPERTIES (
 'serialization.format' = '1'
) LOCATION 's3://cost-and-usage-report-bucket/hourly-report/cur-report/cur-report/'
```